### PR TITLE
Updated the child app to a correct one defined in observability/gdi/lambda-layers

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -27,8 +27,8 @@ Resources:
     Type: AWS::Serverless::Application
     Properties:
       Location:
-        ApplicationId: arn:aws:serverlessrepo:us-east-2:254067382080:applications/signalfx-lambda-nodejs-wrapper-app
-        SemanticVersion: 0.0.4
+        ApplicationId: arn:aws:serverlessrepo:us-east-2:254067382080:applications/wrapper-node-sfx-app
+        SemanticVersion: 0.0.5
     Outputs:
       LayerArn:
         Value:

--- a/templateEncrypted.yaml
+++ b/templateEncrypted.yaml
@@ -31,8 +31,8 @@ Resources:
     Type: AWS::Serverless::Application
     Properties:
       Location:
-        ApplicationId: arn:aws:serverlessrepo:us-east-2:254067382080:applications/signalfx-lambda-nodejs-wrapper-app
-        SemanticVersion: 0.0.4
+        ApplicationId: arn:aws:serverlessrepo:us-east-2:254067382080:applications/wrapper-node-sfx-app
+        SemanticVersion: 0.0.5
     Outputs:
       LayerArn:
         Value:


### PR DESCRIPTION
**signalfx-lambda-nodejs-wrapper-app** became obsolete